### PR TITLE
BundleIdNamingCorrection

### DIFF
--- a/App/VPNManager.swift
+++ b/App/VPNManager.swift
@@ -68,7 +68,7 @@ final class VPNManager: ObservableObject {
         
         // Configure the tunnel provider protocol
         let tunnelProtocol = NETunnelProviderProtocol()
-        tunnelProtocol.providerBundleIdentifier = "com.Conceal.PacketTunnel"
+        tunnelProtocol.providerBundleIdentifier = "com.conceal.concealconnect.PacketTunnel"
         tunnelProtocol.serverAddress = "Conceal PA"  // Display name, actual server is in provider
         
         // Configure the tunnel

--- a/Extensions/PacketTunnel/PacketTunnelProvider.swift
+++ b/Extensions/PacketTunnel/PacketTunnelProvider.swift
@@ -17,8 +17,14 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     private let packetQueue = DispatchQueue(label: "com.conceal.PacketTunnel.packets", qos: .userInitiated)
     private let pollQueue = DispatchQueue(label: "com.conceal.PacketTunnel.poll", qos: .userInitiated)
     
+    override init() {
+        super.init()
+        logger.log("PacketTunnelProvider initialized")
+    }
+    
     override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         logger.log("Starting packet tunnel provider")
+        logger.log("Options received: \(String(describing: options))")
         
         // Instantiate MasqueClient
         masqueClient = MasqueClient()
@@ -26,6 +32,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         // TODO: Extract server host/port from options or configuration
         let serverHost = "10.0.150.43" // Local test server on network
         let serverPort: UInt16 = 6121
+        
+        logger.log("Attempting to connect to MASQUE server at \(serverHost):\(serverPort)")
         
         do {
             // Call connect() on MasqueClient


### PR DESCRIPTION
## Summary
- Fixed bundle identifier mismatch preventing VPN connection
- Added diagnostic logging to help troubleshoot connection issues

## Problem
The VPN was staying in disconnected state (NEVPNStatus=1) when toggling the Private Access switch. This was due to a bundle identifier mismatch between what VPNManager was looking for and the actual PacketTunnel extension identifier.

## Changes
- Updated VPNManager to use the correct bundle identifier: `com.conceal.concealconnect.PacketTunnel` (was using `com.Conceal.PacketTunnel`)
- Added lifecycle logging in PacketTunnelProvider init method
- Added detailed logging for startTunnel including options received
- Added logging for MASQUE server connection attempt details

## Test Plan
- [ ] Build and run on physical iOS device
- [ ] Toggle Private Access switch
- [ ] Check console logs to verify PacketTunnelProvider is initialized
- [ ] Verify connection attempt is made to MASQUE server
- [ ] Check if VPN status changes from disconnected (1) to connecting (2)

🤖 Generated with [Claude Code](https://claude.ai/code)